### PR TITLE
Add resources for JS Regex and Prototypal Patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Mattias Petter Johansson puts the **fun** in functional programming. This is als
 + [You don't know JS](https://github.com/getify/You-Dont-Know-JS)
     + [Scope & closures](https://github.com/getify/You-Dont-Know-JS/tree/master/scope%20%26%20closures)
     + [this & object prototypes](https://github.com/getify/You-Dont-Know-JS/tree/master/this%20%26%20object%20prototypes)
++ [JavaScript Scene](https://medium.com/javascript-scene)
+    + [Master the JavaScript Interview: What is a Closure?](https://medium.com/javascript-scene/master-the-javascript-interview-what-is-a-closure-b2f0d2152b36#.s2y1kihwy)
+    + [Common Misconceptions About Inheritance in JavaScript](https://medium.com/javascript-scene/common-misconceptions-about-inheritance-in-javascript-d5d9bab29b0a)
+    + [3 Different Kinds of Prototypal Inheritance: ES6+ Edition](https://medium.com/javascript-scene/3-different-kinds-of-prototypal-inheritance-es6-edition-32d777fa16c9#.tgnwqubhs)
 
 ### Design patterns and inheritance
 + [Extending classes in JavaScript](http://stackoverflow.com/questions/15192722/javascript-extending-class)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Mattias Petter Johansson puts the **fun** in functional programming. This is als
 + [What is Node.js?](http://stackoverflow.com/a/6782438/494664)
 
 ### Regular expressions
++ [Eloquent JavaScript: Regular Expressions](http://eloquentjavascript.net/09_regexp.html)
++ [What you should know about JavaScript regular expressions](http://bjorn.tipling.com/state-and-regular-expressions-in-javascript)
 + [RegexOne](http://regexone.com/)
 + [Regex Crossword](https://regexcrossword.com/)
 


### PR DESCRIPTION
The current Regex resources don't cover JS painpoints at all, so I've added two resources that cover `lastIndex` and friends.

I've also included three posts from JavaScript Scene, as Eric Elliot has a great way of explaining complex subjects (in this case closures and prototypes) in an understandable way. Especially the prototype section was pretty thin so far.

Let me know if you're okay with these changes.